### PR TITLE
fix pie kernel builds fail

### DIFF
--- a/build/soong/Android.bp
+++ b/build/soong/Android.bp
@@ -26,16 +26,19 @@ bootstrap_go_package {
 
 lineage_generator {
     name: "generated_kernel_includes",
+    
+    // Kernel build error fix by AlexAnanas
+    // Uncomment lines 34, 37, 40, 41 to disable
 
     // The headers make command
-    cmd: "make $(KERNEL_MAKE_FLAGS) -C $(TARGET_KERNEL_SOURCE) O=$(genDir) ARCH=$(KERNEL_ARCH) $(KERNEL_CROSS_COMPILE) headers_install",
+    // cmd: "make $(KERNEL_MAKE_FLAGS) -C $(TARGET_KERNEL_SOURCE) O=$(genDir) ARCH=$(KERNEL_ARCH) $(KERNEL_CROSS_COMPILE) headers_install",
 
     // Directories that can be imported by a cc_* module generated_headers property
-    export_include_dirs: ["usr/include", "usr/techpack/audio/include"],
+    // export_include_dirs: ["usr/include", "usr/techpack/audio/include"],
 
     // Sources for dependency tracking
-    dep_root: "$(TARGET_KERNEL_SOURCE)",
-    dep_files: [ "Makefile", "include/**/*", "arch/$(KERNEL_ARCH)/include/**/*", "techpack/audio/include/**/*"],
+    // dep_root: "$(TARGET_KERNEL_SOURCE)",
+    // dep_files: [ "Makefile", "include/**/*", "arch/$(KERNEL_ARCH)/include/**/*", "techpack/audio/include/**/*"],
 }
 
 cc_library_headers {


### PR DESCRIPTION
Fixes error:
error: vendor/lineage/build/soong/Android.bp:31:8: module "generated_kernel_includes": cmd: unknown variable '$(KERNEL_MAKE_FLAGS)'