### PR TITLE
repopick.py: support manifest without default

### DIFF
--- a/build/tools/repopick.py
+++ b/build/tools/repopick.py
@@ -244,7 +244,7 @@ if __name__ == '__main__':
     xml_root = ElementTree.fromstring(manifest)
     projects = xml_root.findall('project')
     remotes = xml_root.findall('remote')
-    default_revision = xml_root.findall('default')[0].get('revision')
+    default_revision = xml_root.find('default').get('revision') if xml_root.find('default') is not None else None
 
     #dump project data into the a list of dicts with the following data:
     #{project: {path, revision}}


### PR DESCRIPTION
We can see from https://gerrit.googlesource.com/git-repo/+/master/docs/manifest-format.md#XML-File-Format that the default element is singleton and optional. Changed repopick.py to support that.