### PR TITLE
Update Tele2 NL APN

### DIFF
--- a/prebuilt/common/etc/apns-conf.xml
+++ b/prebuilt/common/etc/apns-conf.xml
@@ -45,8 +45,8 @@
   <apn carrier="Wind MMS" mcc="202" mnc="10" apn="mnet.b-online.gr" mmsc="http://192.168.200.95/servlets/mms" mmsport="9401" mmsproxy="192.168.200.11" type="mms" protocol="IP" roaming_protocol="IP" />
   <apn carrier="Nova Internet" mcc="202" mnc="17" apn="internet.nova.gr" type="default" protocol="IPV4V6" roaming_protocol="IPV4V6" />
   <apn carrier="Nova MMS" mcc="202" mnc="17" apn="mms.nova.gr" mmsc="http://mms.nova.gr/mms/" mmsport="8080" mmsproxy="212.251.24.200" type="mms" protocol="IPV4V6" roaming_protocol="IPV4V6" />
-  <apn carrier="Tele2 NL" mcc="204" mnc="02" apn="internet.tele2.nl" mmsc="http://mmsc.tele2.nl" mmsproxy="193.12.40.64" mmsport="8080" type="default,supl,mms" />
-  <apn carrier="Tele2 GPRS" mcc="204" mnc="02" apn="Tele2 GPRS" proxy="130.244.196.090" port="8080" mmsproxy="193.012.040.064" mmsport="8080" mmsc="" user="" password="" type="default,supl,mms" />
+  <apn carrier="Tele2 NL" mcc="204" mnc="16" apn="internet.tele2.nl" mmsc="http://mmsc.tele2.nl" mmsproxy="193.12.40.64" mmsport="8080" type="default,supl,mms" />
+  <apn carrier="Tele2 GPRS" mcc="204" mnc="16" apn="Tele2 GPRS" proxy="130.244.196.090" port="8080" mmsproxy="193.012.040.064" mmsport="8080" mmsc="" user="" password="" type="default,supl,mms" />
   <apn carrier="MVNO NL" mcc="204" mnc="03" apn="internet.mvno.mobi" user="mvno" password="mvno" authtype="1" type="default,supl" mvno_match_data="20403" mvno_type="imsi" />
   <apn carrier="Sphone Pelephone" mcc="204" mnc="04" apn="sphone.pelephone.net.il" user="pcl@3g" password="pcl" type="default,supl" />
   <apn carrier="Multimedia Pelephone" mcc="204" mnc="04" apn="mms.pelephone.net.il" user="pcl@3g" password="pcl" mmsproxy="10.170.252.104" mmsport="9093" mmsc="http://mmsu.pelephone.net.il/" type="mms" />


### PR DESCRIPTION
Tele2 NL recently changed their network infrastructure and therefore requiring a different MNC. 
See also their website:
https://www.tele2.nl/klantenservice/mobiel/toestelhulp/?pagina=device/samsung/galaxy-s9-android-pie/topic/internet/handmatig-instellen/13

The old network uses MNC 02, but the new network requires MNC 16.